### PR TITLE
Bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.1] - 2026-02-25
 
 ### Fixed
-- Fixed `available_indicators` and `available_versions` mutating cached API responses in place, causing `KeyError` on repeated calls
+- Fixed cached data mutation bug: `session_cache` now returns `copy.deepcopy()` of cached results, preventing any call site from corrupting the cache. This fixes issues where `available_versions()` (popping `themeDataStatus`) and `available_indicators()` (popping `dataAvailability`) would corrupt cached data on subsequent calls
+- Removed redundant shallow copy in `_normalize_footnotes`, now unnecessary with the deepcopy-based cache
 - Fixed `available_geo_units` using substring matching (`in`) instead of equality (`==`) for `geoUnitType` filtering
-- Fixed `get_metadata` returning direct references to cached dicts, allowing callers to corrupt the cache
 
 ### Added
 - Idempotency and cache-safety tests for `available_indicators`, `available_versions`, `available_geo_units`, `available_themes`, and `get_metadata`

--- a/src/unesco_reader/config.py
+++ b/src/unesco_reader/config.py
@@ -5,7 +5,8 @@ including custom types and caching utilities.
 
 """
 
-from functools import lru_cache
+import copy
+from functools import lru_cache, wraps
 from typing import Literal
 
 # Custom TYPES
@@ -29,7 +30,14 @@ def session_cache(maxsize: int = 32):
     def decorator(func):
         cached_func = lru_cache(maxsize=maxsize)(func)
         _cached_functions.append(cached_func)
-        return cached_func
+
+        @wraps(cached_func)
+        def wrapper(*args, **kwargs):
+            return copy.deepcopy(cached_func(*args, **kwargs))
+
+        wrapper.cache_info = cached_func.cache_info
+        wrapper.cache_clear = cached_func.cache_clear
+        return wrapper
 
     return decorator
 

--- a/src/unesco_reader/core.py
+++ b/src/unesco_reader/core.py
@@ -6,8 +6,6 @@ The module handles indicator and entity conversions and normalizes data for easy
 The module handles errors and logs hints from the API responses
 """
 
-import copy
-
 import pandas as pd
 from typing import Literal
 
@@ -332,8 +330,7 @@ def get_metadata(
     else:
         response = list(cached_response)
 
-    # Return deep copies to avoid callers mutating the cached API data
-    return copy.deepcopy(response)
+    return response
 
 
 def _indicators_df(indicators: list[dict]) -> pd.DataFrame:

--- a/src/unesco_reader/core.py
+++ b/src/unesco_reader/core.py
@@ -349,9 +349,7 @@ def _indicators_df(indicators: list[dict]) -> pd.DataFrame:
     # Flatten the data for DataFrame return without mutating the original records
     rows = []
     for record in indicators:
-        row = {
-            k: v for k, v in record.items() if k != "dataAvailability"
-        }
+        row = {k: v for k, v in record.items() if k != "dataAvailability"}
         da = record["dataAvailability"]
         row["timeLine_min"] = da["timeLine"]["min"]
         row["timeLine_max"] = da["timeLine"]["max"]

--- a/src/unesco_reader/core.py
+++ b/src/unesco_reader/core.py
@@ -129,7 +129,6 @@ def _normalize_footnotes(data: list[dict]) -> list[dict]:
 
     normalized = []
     for record in data:
-        record = {**record}  # shallow copy to avoid mutating the original
         if len(record["footnotes"]) == 0:
             record["footnotes"] = None
         else:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -173,7 +173,9 @@ def test_session_cache_deep_mutation_protection():
         result1["a"]["new_key"] = "injected"
 
         result2 = get_nested()
-        assert result2 == {"a": {"b": [1, 2, 3]}}, "Cache was corrupted by deep mutation"
+        assert result2 == {
+            "a": {"b": [1, 2, 3]}
+        }, "Cache was corrupted by deep mutation"
     finally:
         get_nested.cache_clear()
 
@@ -189,7 +191,9 @@ def test_available_versions_does_not_corrupt_get_versions_cache():
         # get_versions should still return records with themeDataStatus intact
         versions = api.get_versions()
         for v in versions:
-            assert "themeDataStatus" in v, "get_versions cache corrupted by available_versions"
+            assert (
+                "themeDataStatus" in v
+            ), "get_versions cache corrupted by available_versions"
 
 
 def test_available_indicators_does_not_corrupt_get_indicators_cache():
@@ -216,7 +220,9 @@ def test_available_indicators_does_not_corrupt_get_indicators_cache():
         # get_indicators should still have dataAvailability
         indicators = api.get_indicators()
         for ind in indicators:
-            assert "dataAvailability" in ind, "get_indicators cache corrupted by available_indicators"
+            assert (
+                "dataAvailability" in ind
+            ), "get_indicators cache corrupted by available_indicators"
 
 
 def test_session_cache_cache_clear_still_works():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -138,3 +138,103 @@ def test_clear_cache_exposed_at_package_level():
 
     assert hasattr(unesco_reader, "clear_cache")
     assert callable(unesco_reader.clear_cache)
+
+
+def test_session_cache_shallow_mutation_protection():
+    """Mutating a returned value must not corrupt the cache."""
+    from unesco_reader.config import session_cache
+
+    @session_cache(maxsize=2)
+    def get_items():
+        return [{"key": "value"}]
+
+    try:
+        result1 = get_items()
+        result1[0]["key"] = "corrupted"
+        result1.append({"extra": True})
+
+        result2 = get_items()
+        assert result2 == [{"key": "value"}], "Cache was corrupted by shallow mutation"
+    finally:
+        get_items.cache_clear()
+
+
+def test_session_cache_deep_mutation_protection():
+    """Mutating nested structures must not corrupt the cache."""
+    from unesco_reader.config import session_cache
+
+    @session_cache(maxsize=2)
+    def get_nested():
+        return {"a": {"b": [1, 2, 3]}}
+
+    try:
+        result1 = get_nested()
+        result1["a"]["b"].append(999)
+        result1["a"]["new_key"] = "injected"
+
+        result2 = get_nested()
+        assert result2 == {"a": {"b": [1, 2, 3]}}, "Cache was corrupted by deep mutation"
+    finally:
+        get_nested.cache_clear()
+
+
+def test_available_versions_does_not_corrupt_get_versions_cache():
+    """available_versions() pops 'themeDataStatus'; this must not affect get_versions()."""
+    from unesco_reader import core
+
+    with patch("unesco_reader.api._make_request", return_value=mock_list_versions):
+        clear_cache()
+        # available_versions internally pops themeDataStatus
+        core.available_versions()
+        # get_versions should still return records with themeDataStatus intact
+        versions = api.get_versions()
+        for v in versions:
+            assert "themeDataStatus" in v, "get_versions cache corrupted by available_versions"
+
+
+def test_available_indicators_does_not_corrupt_get_indicators_cache():
+    """available_indicators() pops 'dataAvailability'; this must not affect get_indicators()."""
+    from unesco_reader import core
+
+    mock_indicators = [
+        {
+            "indicatorCode": "CR.1",
+            "name": "Test",
+            "lastDataUpdate": "2024-01-01",
+            "dataAvailability": {
+                "timeLine": {"min": 2000, "max": 2020},
+                "totalRecordCount": 100,
+                "geoUnits": {"types": ["NATIONAL"]},
+            },
+        }
+    ]
+
+    with patch("unesco_reader.api._make_request", return_value=mock_indicators):
+        clear_cache()
+        # available_indicators internally pops dataAvailability
+        core.available_indicators()
+        # get_indicators should still have dataAvailability
+        indicators = api.get_indicators()
+        for ind in indicators:
+            assert "dataAvailability" in ind, "get_indicators cache corrupted by available_indicators"
+
+
+def test_session_cache_cache_clear_still_works():
+    """cache_clear on the wrapper must invalidate the underlying lru_cache."""
+    from unesco_reader.config import session_cache
+
+    call_count = 0
+
+    @session_cache(maxsize=2)
+    def counter():
+        nonlocal call_count
+        call_count += 1
+        return call_count
+
+    try:
+        assert counter() == 1
+        assert counter() == 1  # cached
+        counter.cache_clear()
+        assert counter() == 2  # fresh call after clear
+    finally:
+        counter.cache_clear()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,6 +15,7 @@ from mock_api_response import (
     mock_default_version,
     mock_list_versions,
 )
+from unesco_reader.config import clear_cache
 from unesco_reader.exceptions import NoDataError
 
 
@@ -1624,9 +1625,10 @@ def test_available_geo_units_filter_uses_equality_not_substring():
 def test_get_metadata_does_not_mutate_cache():
     """get_metadata should return deep copies so callers cannot corrupt the cache."""
     with patch(
-        "unesco_reader.api.get_indicators",
+        "unesco_reader.api._make_request",
         return_value=mock_indicators_no_agg_no_glossary,
     ):
+        clear_cache()
         result = core.get_metadata()
         # Mutate the returned data
         result[0]["name"] = "CORRUPTED"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1559,9 +1559,7 @@ def test_available_indicators_does_not_mutate_source():
 
 def test_available_versions_idempotent():
     """Calling available_versions twice should return the same result."""
-    with patch(
-        "unesco_reader.api.get_versions", return_value=mock_list_versions
-    ):
+    with patch("unesco_reader.api.get_versions", return_value=mock_list_versions):
         first = core.available_versions()
         second = core.available_versions()
         pd.testing.assert_frame_equal(first, second)
@@ -1569,9 +1567,7 @@ def test_available_versions_idempotent():
 
 def test_available_versions_raw_idempotent():
     """Calling available_versions with raw=True twice should return the same result."""
-    with patch(
-        "unesco_reader.api.get_versions", return_value=mock_list_versions
-    ):
+    with patch("unesco_reader.api.get_versions", return_value=mock_list_versions):
         first = core.available_versions(raw=True)
         second = core.available_versions(raw=True)
         assert first == second
@@ -1591,9 +1587,7 @@ def test_available_versions_does_not_mutate_source():
 
 def test_available_geo_units_idempotent():
     """Calling available_geo_units twice should return the same result."""
-    with patch(
-        "unesco_reader.api.get_geo_units", return_value=mock_geo_units
-    ):
+    with patch("unesco_reader.api.get_geo_units", return_value=mock_geo_units):
         first = core.available_geo_units()
         second = core.available_geo_units()
         pd.testing.assert_frame_equal(first, second)
@@ -1614,11 +1608,14 @@ def test_available_geo_units_filter_uses_equality_not_substring():
     mock_geo_units_with_sub = [
         {"id": "ABW", "name": "Aruba", "type": "NATIONAL"},
         {"id": "X1", "name": "Subnational Region", "type": "SUBNATIONAL"},
-        {"id": "UNESCO: SIDS", "name": "SIDS", "type": "REGIONAL", "regionGroup": "UNESCO"},
+        {
+            "id": "UNESCO: SIDS",
+            "name": "SIDS",
+            "type": "REGIONAL",
+            "regionGroup": "UNESCO",
+        },
     ]
-    with patch(
-        "unesco_reader.api.get_geo_units", return_value=mock_geo_units_with_sub
-    ):
+    with patch("unesco_reader.api.get_geo_units", return_value=mock_geo_units_with_sub):
         result = core.available_geo_units(geoUnitType="NATIONAL")
         assert len(result) == 1
         assert result.iloc[0]["id"] == "ABW"


### PR DESCRIPTION
This pull request addresses a critical cache safety issue in the `unesco_reader` package by ensuring that cached API responses are never mutated by callers. The changes introduce deep copying for all cached results, preventing subtle bugs caused by in-place mutations, and add comprehensive tests to guarantee this behavior. Additionally, redundant code is removed as a result of the improved cache safety.

**Cache Safety Improvements:**

* The `session_cache` decorator in `src/unesco_reader/config.py` now returns a `copy.deepcopy()` of cached results, ensuring that any mutation to returned data does not affect the cache. This fixes bugs where functions like `available_versions()` and `available_indicators()` could corrupt cached data by popping fields from the returned dicts. [[1]](diffhunk://#diff-4b282e0a8880ca335848f657e55a98d1f8544cb618bd084b8c46bc65c4bed6c4L8-R9) [[2]](diffhunk://#diff-4b282e0a8880ca335848f657e55a98d1f8544cb618bd084b8c46bc65c4bed6c4L32-R40)
* Removed the redundant shallow copy in `_normalize_footnotes` in `src/unesco_reader/core.py`, as deep copies from the cache now make this unnecessary.

**Testing Enhancements:**

* Added new tests in `tests/test_cache.py` to verify that both shallow and deep mutations of cached return values do not corrupt the cache, and that cache clearing still works as expected. Also added regression tests to ensure `available_versions()` and `available_indicators()` do not corrupt the underlying cache for `get_versions()` and `get_indicators()`.

**Documentation:**

* Updated the changelog to reflect the cache mutation bugfix, the removal of the redundant shallow copy, and the addition of new cache-safety tests.